### PR TITLE
Make sure that the order of Requires-Dist does not matter

### DIFF
--- a/tests/test_frontend_setuptools.py
+++ b/tests/test_frontend_setuptools.py
@@ -75,7 +75,7 @@ def test_setuptools_prepare_metadata_for_build_wheel(frontend_setuptools: Subpro
     assert dist.metadata["Name"] == "demo"
     values = [v for k, v in dist.metadata.items() if k == "Requires-Dist"]  # type: ignore[attr-defined]
     # ignore because "PackageMetadata" has no attribute "items"
-    assert values == ["requests >2", "magic >3"]
+    assert sorted(values) == ["magic >3", "requests >2"]
     assert isinstance(result.out, str)
     assert isinstance(result.err, str)
 


### PR DESCRIPTION
Fixes: #77

Would it be possible to make a new release? We are updating to the latest wheel and the tests of the latest stable pyproject-api are not compatible with it.